### PR TITLE
docs: use npm start instead of ember server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bower install
 Start dev server
 
 ```
-ember server
+npm start
 ```
 
 Ues [ember-hoodie](https://github.com/courajs/ember-hoodie). If you see an error


### PR DESCRIPTION
This way we don't need the globally installed `ember` package (which might be different to the one the app is using) and we're also using NPM's standard way of starting things